### PR TITLE
Replace Interface with abstract class

### DIFF
--- a/FizzBuzz.Tests/FizzerBuzzerTests.cs
+++ b/FizzBuzz.Tests/FizzerBuzzerTests.cs
@@ -11,9 +11,12 @@ public class FizzBuzzerTests
 
     private void SetupToApplyExpectedTransform()
     {
-        var transform = new Mock<ITransform>();
-        transform.Setup(r => r.Apply(ExpectedMatch))
-            .Returns(ExpectedTransformed);
+        var transform = new Mock<Transform>();
+        transform.Setup(r => r.Match)
+            .Returns(i => i == ExpectedMatch);
+        transform.Setup(r => r.Transformation)
+            .Returns(i => ExpectedTransformed);
+
 
         fizzBuzzer = new FizzBuzzer(transform.Object);
     }
@@ -37,13 +40,17 @@ public class FizzBuzzerTests
     [Fact]
     public void ShouldApplyTransformsInOrder()
     {
-        var firstTransform = new Mock<ITransform>();
-        firstTransform.Setup(t => t.Apply(ExpectedMatch))
-            .Returns(ExpectedTransformed);
+        var firstTransform = new Mock<Transform>();
+        firstTransform.Setup(r => r.Match)
+            .Returns(i => i == ExpectedMatch);
+        firstTransform.Setup(r => r.Transformation)
+            .Returns(i => ExpectedTransformed);
 
-        var secondTransform = new Mock<ITransform>();
-        secondTransform.Setup(t => t.Apply(ExpectedMatch))
-            .Returns(OtherTransformed);
+        var secondTransform = new Mock<Transform>();
+        secondTransform.Setup(r => r.Match)
+            .Returns(i => i == ExpectedMatch);
+        secondTransform.Setup(r => r.Transformation)
+            .Returns(i => OtherTransformed);
 
         var fizzBuzzerOne = new FizzBuzzer(firstTransform.Object, secondTransform.Object);
         var fizzBuzzerTwo = new FizzBuzzer(secondTransform.Object, firstTransform.Object);

--- a/FizzBuzz.Tests/TransformTests.cs
+++ b/FizzBuzz.Tests/TransformTests.cs
@@ -1,0 +1,32 @@
+﻿namespace FizzBuzz.Tests;
+
+public class TransformTests
+{
+    private Transform transform;
+
+    private const int ExpectedMatch = 3;
+    private const string ExpectedTransformed = "Transformed";
+
+    public TransformTests()
+    {
+        var transformMock = new Mock<Transform>();
+        transformMock.Setup(t => t.Match)
+            .Returns(i => i == ExpectedMatch);
+        transformMock.Setup(t => t.Transformation)
+            .Returns(i => ExpectedTransformed);
+
+        transform = transformMock.Object;
+    }
+
+    [Fact]
+    public void ShouldApplyTransformWhenMatched() 
+        => transform
+            .Apply(ExpectedMatch)
+            .ShouldBe(ExpectedTransformed);
+
+    [Fact]
+    public void ShouldBeEmptyWhenNotMatched()
+        => transform
+            .Apply(ExpectedMatch + 1)
+            .ShouldBe(string.Empty);
+}

--- a/FizzBuzz/FizzBuzzer.cs
+++ b/FizzBuzz/FizzBuzzer.cs
@@ -2,9 +2,9 @@ namespace FizzBuzz;
 
 public class FizzBuzzer
 {
-    private readonly IEnumerable<ITransform> transforms;
+    private readonly IEnumerable<Transform> transforms;
 
-    public FizzBuzzer(params ITransform[] transforms)
+    public FizzBuzzer(params Transform[] transforms)
     {
         this.transforms = transforms;
     }

--- a/FizzBuzz/ITransform.cs
+++ b/FizzBuzz/ITransform.cs
@@ -1,9 +1,0 @@
-namespace FizzBuzz;
-
-public interface ITransform 
-{
-    /* The problem with this solution is that each Transform has to know it should return empty string when there is no match
-     * Also the responsibility of applying the transform should happen in one place => refactoring go!
-     */
-    string Apply(int i);
-}

--- a/FizzBuzz/Transform.cs
+++ b/FizzBuzz/Transform.cs
@@ -1,0 +1,12 @@
+﻿namespace FizzBuzz;
+
+public abstract class Transform
+{
+    public abstract Func<int, bool> Match { get; }
+    public abstract Func<int, string> Transformation { get; }
+
+    public string Apply(int i) => 
+        Match(i) 
+            ? Transformation(i) 
+            : string.Empty;
+}

--- a/FizzBuzz/Transforms/BuzzTransform.cs
+++ b/FizzBuzz/Transforms/BuzzTransform.cs
@@ -1,11 +1,7 @@
 ﻿namespace FizzBuzz.Transforms;
 
-public class BuzzTransform : ITransform
+public class BuzzTransform : Transform
 {
-    public string Apply(int i)
-    {
-        return (i % 5 == 0) 
-            ? "Buzz" 
-            : string.Empty;
-    }
+    public override Func<int, bool> Match => i => i % 5 == 0;
+    public override Func<int, string> Transformation => i => "Buzz";
 }

--- a/FizzBuzz/Transforms/BuzzyTransform.cs
+++ b/FizzBuzz/Transforms/BuzzyTransform.cs
@@ -1,11 +1,8 @@
 ﻿namespace FizzBuzz.Transforms;
 
-public class BuzzyTransform : ITransform
+public class BuzzyTransform : Transform
 {
-    public string Apply(int i)
-    {
-        return i.ToString().Contains('5') 
-            ? "Buzzy" 
-            : string.Empty;
-    }
+    public override Func<int, bool> Match => i => i.ToString().Contains('5');
+
+    public override Func<int, string> Transformation => i => "Buzzy";
 }

--- a/FizzBuzz/Transforms/FizzTransform.cs
+++ b/FizzBuzz/Transforms/FizzTransform.cs
@@ -1,8 +1,7 @@
 ﻿namespace FizzBuzz.Transforms;
 
-public class FizzTransform : ITransform
+public class FizzTransform : Transform
 {
-    public string Apply(int i) => (i % 3 == 0) 
-        ? "Fizz" 
-        : string.Empty;
+    public override Func<int, bool> Match => i => i % 3 == 0;
+    public override Func<int, string> Transformation => i => "Fizz";
 }

--- a/FizzBuzz/Transforms/FizzyTransform.cs
+++ b/FizzBuzz/Transforms/FizzyTransform.cs
@@ -1,8 +1,8 @@
 ﻿namespace FizzBuzz.Transforms;
 
-public class FizzyTransform : ITransform
+public class FizzyTransform : Transform
 {
-    public string Apply(int i) => i.ToString().Contains('3') 
-        ? "Fizzy" 
-        : string.Empty;
+    public override Func<int, bool> Match => i => i.ToString().Contains('3');
+
+    public override Func<int, string> Transformation => i => "Fizzy";
 }


### PR DESCRIPTION
Replace the interface with an abstract class so that the knowledge of what to do when the match is found is centralised in one place